### PR TITLE
Add blog posts with manager moderation and structured logging

### DIFF
--- a/public/employee.html
+++ b/public/employee.html
@@ -1,13 +1,56 @@
 <h2>Employee Dashboard</h2>
-<button onclick="viewProfile()">View My Profile</button>
+<section>
+  <button onclick="viewProfile()">View My Profile</button>
+</section>
+
+<section>
+  <h3>Create Post</h3>
+  <form id="postForm">
+    <textarea name="content" required></textarea>
+    <button type="submit">Post</button>
+  </form>
+</section>
+
+<section>
+  <h3>Posts</h3>
+  <ul id="postList"></ul>
+</section>
 
 <script>
+  const token = localStorage.getItem('token');
+
   async function viewProfile() {
-    const token = localStorage.getItem('token');
     const res = await fetch('/api/users/me', {
       headers: { 'Authorization': `Bearer ${token}` }
     });
     const data = await res.json();
     alert(JSON.stringify(data));
   }
+
+  document.getElementById('postForm').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const content = e.target.content.value.trim();
+    if (!content) return;
+    await fetch('/api/posts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+      body: JSON.stringify({ content })
+    });
+    e.target.reset();
+    loadPosts();
+  });
+
+  async function loadPosts() {
+    const res = await fetch('/api/posts');
+    const posts = await res.json();
+    const list = document.getElementById('postList');
+    list.innerHTML = '';
+    posts.forEach(p => {
+      const li = document.createElement('li');
+      li.textContent = `${p.author}: ${p.content}`;
+      list.appendChild(li);
+    });
+  }
+
+  loadPosts();
 </script>

--- a/public/manager.html
+++ b/public/manager.html
@@ -1,13 +1,66 @@
 <h2>Manager Dashboard</h2>
-<button onclick="viewUsers()">View Employees</button>
+<section>
+  <button onclick="viewUsers()">View Employees</button>
+</section>
+
+<section>
+  <h3>Create Post</h3>
+  <form id="postForm">
+    <textarea name="content" required></textarea>
+    <button type="submit">Post</button>
+  </form>
+</section>
+
+<section>
+  <h3>Posts</h3>
+  <ul id="postList"></ul>
+</section>
 
 <script>
+  const token = localStorage.getItem('token');
+
   async function viewUsers() {
-    const token = localStorage.getItem('token');
     const res = await fetch('/api/users', {
       headers: { 'Authorization': `Bearer ${token}` }
     });
     const data = await res.json();
     alert(JSON.stringify(data));
   }
+
+  document.getElementById('postForm').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const content = e.target.content.value.trim();
+    if (!content) return;
+    await fetch('/api/posts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+      body: JSON.stringify({ content })
+    });
+    e.target.reset();
+    loadPosts();
+  });
+
+  async function loadPosts() {
+    const res = await fetch('/api/posts');
+    const posts = await res.json();
+    const list = document.getElementById('postList');
+    list.innerHTML = '';
+    posts.forEach(p => {
+      const li = document.createElement('li');
+      li.textContent = `${p.author}: ${p.content}`;
+      const delBtn = document.createElement('button');
+      delBtn.textContent = 'Delete';
+      delBtn.onclick = async () => {
+        await fetch(`/api/posts/${p.id}`, {
+          method: 'DELETE',
+          headers: { 'Authorization': `Bearer ${token}` }
+        });
+        loadPosts();
+      };
+      li.appendChild(delBtn);
+      list.appendChild(li);
+    });
+  }
+
+  loadPosts();
 </script>

--- a/server/app.js
+++ b/server/app.js
@@ -6,11 +6,13 @@ const app = express();
 const authRoutes = require('./routes/auth.routes');
 const userRoutes = require('./routes/user.routes');
 const logRoutes = require('./routes/log.routes');
+const postRoutes = require('./routes/post.routes');
 
 app.use(express.json());
 app.use('/api/auth', authRoutes);
 app.use('/api/users', userRoutes);
 app.use('/api/logs', logRoutes);
+app.use('/api/posts', postRoutes);
 app.use('/src', express.static(path.join(__dirname, '../src')));
 app.use('/', express.static(path.join(__dirname, '../public')));
 

--- a/server/controllers/log.controller.js
+++ b/server/controllers/log.controller.js
@@ -1,7 +1,8 @@
+const { info } = require('../utils/logger');
 const logs = [];
 
 function addLog(action, user) {
-    console.log(`Log Action: ${action} by User: ${user}`);
+    info(action, user);
     logs.push({
         id: logs.length + 1,
         action,

--- a/server/controllers/post.controller.js
+++ b/server/controllers/post.controller.js
@@ -1,0 +1,32 @@
+const { posts } = require('../database');
+const { addLog } = require('./log.controller');
+
+let nextId = 1;
+
+const listPosts = (req, res) => {
+    res.json(posts);
+};
+
+const createPost = (req, res) => {
+    const { content } = req.body;
+    if (!content) {
+        return res.status(400).json({ message: 'Content is required' });
+    }
+    const post = { id: nextId++, content, author: req.user.username };
+    posts.push(post);
+    addLog(`Created post ID ${post.id}`, req.user.username);
+    res.json(post);
+};
+
+const deletePost = (req, res) => {
+    const id = parseInt(req.params.id);
+    const index = posts.findIndex(p => p.id === id);
+    if (index === -1) {
+        return res.status(404).json({ message: 'Post not found' });
+    }
+    posts.splice(index, 1);
+    addLog(`Deleted post ID ${id}`, req.user.username);
+    res.json({ message: 'Post deleted' });
+};
+
+module.exports = { listPosts, createPost, deletePost };

--- a/server/database.js
+++ b/server/database.js
@@ -6,4 +6,7 @@ const users = [
     { id: 3, username: 'employee', password: bcrypt.hashSync('employee123', 10), role: 'employee' },
 ];
 
-module.exports = { users };
+// In-memory storage for blog posts
+const posts = [];
+
+module.exports = { users, posts };

--- a/server/routes/post.routes.js
+++ b/server/routes/post.routes.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const { listPosts, createPost, deletePost } = require('../controllers/post.controller');
+const { verifyToken } = require('../middlewares/auth.middleware');
+const { allowRoles } = require('../middlewares/role.middleware');
+
+const router = express.Router();
+
+router.get('/', listPosts);
+router.post('/', verifyToken, createPost);
+router.delete('/:id', verifyToken, allowRoles('admin', 'manager'), deletePost);
+
+module.exports = router;

--- a/server/utils/logger.js
+++ b/server/utils/logger.js
@@ -1,0 +1,11 @@
+function info(action, user) {
+    const entry = {
+        level: 'info',
+        timestamp: new Date().toISOString(),
+        user,
+        action
+    };
+    console.log(JSON.stringify(entry));
+}
+
+module.exports = { info };


### PR DESCRIPTION
## Summary
- allow authenticated users to create blog posts
- let managers and admins remove posts
- improve log format with structured JSON output

## Testing
- `npm test` (fails: Missing script "test")
- `node server/app.js` (server started then was stopped)

------
https://chatgpt.com/codex/tasks/task_e_688f253e2018832ea429e9e07897f9b1