### PR TITLE
Add blog posts with manager moderation and structured logging

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -6,6 +6,7 @@
         <input name="username" placeholder="Username" required />
         <input name="password" type="password" placeholder="Password" required />
         <select name="role">
+            <option value="admin">Administrator</option>
             <option value="manager">Manager</option>
             <option value="employee">Employee</option>
         </select>
@@ -19,7 +20,16 @@
 </section>
 
 <section>
+    <h3>Change Password</h3>
+    <form id="passwordForm">
+        <input name="password" type="password" placeholder="New Password" required />
+        <button type="submit">Update</button>
+    </form>
+</section>
+
+<section>
     <h3>Application Logs</h3>
+    <input id="logFilter" placeholder="Filter" />
     <button onclick="loadLogs()">View Logs</button>
     <ul id="logList"></ul>
 </section>
@@ -64,7 +74,31 @@
         list.innerHTML = '';
         users.forEach(user => {
             const li = document.createElement('li');
-            li.textContent = `${user.username} (${user.role})`;
+            li.textContent = `${user.username}`;
+
+            const roleSelect = document.createElement('select');
+            ['admin', 'manager', 'employee'].forEach(r => {
+                const opt = document.createElement('option');
+                opt.value = r;
+                opt.textContent = r.charAt(0).toUpperCase() + r.slice(1);
+                if (user.role === r) opt.selected = true;
+                roleSelect.appendChild(opt);
+            });
+
+            const saveBtn = document.createElement('button');
+            saveBtn.innerText = 'Change Role';
+            saveBtn.onclick = async () => {
+                await fetch(`/api/users/${user.id}/role`, {
+                    method: 'PUT',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Authorization': `Bearer ${token}`
+                    },
+                    body: JSON.stringify({ role: roleSelect.value })
+                });
+                loadUsers();
+                loadLogs();
+            };
 
             const deleteBtn = document.createElement('button');
             deleteBtn.innerText = 'Delete';
@@ -77,28 +111,14 @@
                 loadLogs();
             };
 
-            const promoteBtn = document.createElement('button');
-            promoteBtn.innerText = 'Make Manager';
-            promoteBtn.onclick = async () => {
-                await fetch(`/api/users/${user.id}/role`, {
-                    method: 'PUT',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'Authorization': `Bearer ${token}`
-                    },
-                    body: JSON.stringify({ role: 'manager' })
-                });
-                loadUsers();
-                loadLogs();
-            };
-
-            li.append(deleteBtn, promoteBtn);
+            li.append(` (${user.role}) `, roleSelect, saveBtn, deleteBtn);
             list.appendChild(li);
         });
     }
 
     async function loadLogs() {
-        const res = await fetch('/api/logs', {
+        const q = document.getElementById('logFilter').value;
+        const res = await fetch(`/api/logs${q ? `?q=${encodeURIComponent(q)}` : ''}`, {
             headers: { 'Authorization': `Bearer ${token}` }
         });
         const logs = await res.json();
@@ -110,6 +130,17 @@
             logList.appendChild(li);
         });
     }
+
+    document.getElementById('passwordForm').addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const password = e.target.password.value;
+        await fetch('/api/users/password', {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+            body: JSON.stringify({ password })
+        });
+        e.target.reset();
+    });
 
     loadUsers();
 </script>

--- a/public/employee.html
+++ b/public/employee.html
@@ -1,13 +1,80 @@
 <h2>Employee Dashboard</h2>
-<button onclick="viewProfile()">View My Profile</button>
+<section>
+  <button onclick="viewProfile()">View My Profile</button>
+</section>
+
+<section>
+  <h3>Create Post</h3>
+  <form id="postForm">
+    <textarea name="content" required></textarea>
+    <button type="submit">Post</button>
+  </form>
+</section>
+
+<section>
+  <h3>Posts</h3>
+  <ul id="postList"></ul>
+</section>
 
 <script>
+  const token = localStorage.getItem('token');
+
   async function viewProfile() {
-    const token = localStorage.getItem('token');
     const res = await fetch('/api/users/me', {
       headers: { 'Authorization': `Bearer ${token}` }
     });
     const data = await res.json();
     alert(JSON.stringify(data));
   }
+
+  document.getElementById('postForm').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const content = e.target.content.value.trim();
+    if (!content) return;
+    await fetch('/api/posts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+      body: JSON.stringify({ content })
+    });
+    e.target.reset();
+    loadPosts();
+  });
+
+  async function loadPosts() {
+    const res = await fetch('/api/posts', {
+      headers: { 'Authorization': `Bearer ${token}` }
+    });
+    const posts = await res.json();
+    const list = document.getElementById('postList');
+    list.innerHTML = '';
+    posts.forEach(p => {
+      const li = document.createElement('li');
+      li.textContent = `${p.author}: ${p.content} (${new Date(p.createdAt).toLocaleString()})`;
+      const editBtn = document.createElement('button');
+      editBtn.textContent = 'Edit';
+      editBtn.onclick = async () => {
+        const content = prompt('Edit post', p.content);
+        if (!content) return;
+        await fetch(`/api/posts/${p.id}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+          body: JSON.stringify({ content })
+        });
+        loadPosts();
+      };
+      const delBtn = document.createElement('button');
+      delBtn.textContent = 'Delete';
+      delBtn.onclick = async () => {
+        await fetch(`/api/posts/${p.id}`, {
+          method: 'DELETE',
+          headers: { 'Authorization': `Bearer ${token}` }
+        });
+        loadPosts();
+      };
+      li.append(editBtn, delBtn);
+      list.appendChild(li);
+    });
+  }
+
+  loadPosts();
 </script>

--- a/public/manager.html
+++ b/public/manager.html
@@ -1,13 +1,99 @@
 <h2>Manager Dashboard</h2>
-<button onclick="viewUsers()">View Employees</button>
+<section>
+  <button onclick="viewUsers()">View Employees</button>
+</section>
+
+<section>
+  <h3>Create Post</h3>
+  <form id="postForm">
+    <textarea name="content" required></textarea>
+    <button type="submit">Post</button>
+  </form>
+</section>
+
+<section>
+  <h3>Posts</h3>
+  <ul id="postList"></ul>
+</section>
+
+<section>
+  <h3>Change Password</h3>
+  <form id="passwordForm">
+    <input name="password" type="password" placeholder="New Password" required />
+    <button type="submit">Update</button>
+  </form>
+</section>
 
 <script>
+  const token = localStorage.getItem('token');
+
   async function viewUsers() {
-    const token = localStorage.getItem('token');
     const res = await fetch('/api/users', {
       headers: { 'Authorization': `Bearer ${token}` }
     });
     const data = await res.json();
     alert(JSON.stringify(data));
   }
+
+  document.getElementById('postForm').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const content = e.target.content.value.trim();
+    if (!content) return;
+    await fetch('/api/posts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+      body: JSON.stringify({ content })
+    });
+    e.target.reset();
+    loadPosts();
+  });
+
+  async function loadPosts() {
+    const res = await fetch('/api/posts', {
+      headers: { 'Authorization': `Bearer ${token}` }
+    });
+    const posts = await res.json();
+    const list = document.getElementById('postList');
+    list.innerHTML = '';
+    posts.forEach(p => {
+      const li = document.createElement('li');
+      li.textContent = `${p.author}: ${p.content} (${new Date(p.createdAt).toLocaleString()})`;
+      const editBtn = document.createElement('button');
+      editBtn.textContent = 'Edit';
+      editBtn.onclick = async () => {
+        const content = prompt('Edit post', p.content);
+        if (!content) return;
+        await fetch(`/api/posts/${p.id}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+          body: JSON.stringify({ content })
+        });
+        loadPosts();
+      };
+      const delBtn = document.createElement('button');
+      delBtn.textContent = 'Delete';
+      delBtn.onclick = async () => {
+        await fetch(`/api/posts/${p.id}`, {
+          method: 'DELETE',
+          headers: { 'Authorization': `Bearer ${token}` }
+        });
+        loadPosts();
+      };
+      li.append(editBtn, delBtn);
+      list.appendChild(li);
+    });
+  }
+
+  document.getElementById('passwordForm').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const password = e.target.password.value;
+    await fetch('/api/users/password', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+      body: JSON.stringify({ password })
+    });
+    e.target.reset();
+  });
+
+  loadPosts();
 </script>

--- a/server/app.js
+++ b/server/app.js
@@ -6,11 +6,13 @@ const app = express();
 const authRoutes = require('./routes/auth.routes');
 const userRoutes = require('./routes/user.routes');
 const logRoutes = require('./routes/log.routes');
+const postRoutes = require('./routes/post.routes');
 
 app.use(express.json());
 app.use('/api/auth', authRoutes);
 app.use('/api/users', userRoutes);
 app.use('/api/logs', logRoutes);
+app.use('/api/posts', postRoutes);
 app.use('/src', express.static(path.join(__dirname, '../src')));
 app.use('/', express.static(path.join(__dirname, '../public')));
 

--- a/server/controllers/auth.controller.js
+++ b/server/controllers/auth.controller.js
@@ -11,7 +11,7 @@ const login = async (req, res) => {
     const valid = await bcrypt.compare(password, user.password);
     if (!valid) return res.status(401).json({ message: 'Invalid password' });
 
-    const token = jwt.sign({ id: user.id, role: user.role }, SECRET, { expiresIn: '1h' });
+    const token = jwt.sign({ id: user.id, role: user.role, username: user.username }, SECRET, { expiresIn: '1h' });
     res.json({ token, role: user.role });
 };
 

--- a/server/controllers/log.controller.js
+++ b/server/controllers/log.controller.js
@@ -1,7 +1,8 @@
+const { info } = require('../utils/logger');
 const logs = [];
 
 function addLog(action, user) {
-    console.log(`Log Action: ${action} by User: ${user}`);
+    info(action, user);
     logs.push({
         id: logs.length + 1,
         action,
@@ -11,7 +12,14 @@ function addLog(action, user) {
 }
 
 const getLogs = (req, res) => {
-    res.json(logs);
+    const { q } = req.query;
+    const filtered = q
+        ? logs.filter(l =>
+            l.action.toLowerCase().includes(q.toLowerCase()) ||
+            l.user.toLowerCase().includes(q.toLowerCase())
+        )
+        : logs;
+    res.json(filtered);
 };
 
 module.exports = { getLogs, addLog };

--- a/server/controllers/post.controller.js
+++ b/server/controllers/post.controller.js
@@ -1,0 +1,59 @@
+const { posts } = require('../database');
+const { addLog } = require('./log.controller');
+
+let nextId = 1;
+
+const listPosts = (req, res) => {
+    const visible = ['manager', 'admin'].includes(req.user.role)
+        ? posts
+        : posts.filter(p => p.authorId === req.user.id);
+    res.json(visible);
+};
+
+const createPost = (req, res) => {
+    const { content } = req.body;
+    if (!content) {
+        return res.status(400).json({ message: 'Content is required' });
+    }
+    const now = new Date().toISOString();
+    const post = {
+        id: nextId++,
+        content,
+        authorId: req.user.id,
+        author: req.user.username,
+        createdAt: now,
+        updatedAt: now
+    };
+    posts.push(post);
+    addLog(`Created post ID ${post.id}`, req.user.username);
+    res.json(post);
+};
+
+const updatePost = (req, res) => {
+    const id = parseInt(req.params.id);
+    const { content } = req.body;
+    const post = posts.find(p => p.id === id);
+    if (!post) return res.status(404).json({ message: 'Post not found' });
+    const canEdit = ['manager', 'admin'].includes(req.user.role) || post.authorId === req.user.id;
+    if (!canEdit) return res.status(403).json({ message: 'Forbidden' });
+    post.content = content || post.content;
+    post.updatedAt = new Date().toISOString();
+    addLog(`Updated post ID ${id}`, req.user.username);
+    res.json(post);
+};
+
+const deletePost = (req, res) => {
+    const id = parseInt(req.params.id);
+    const index = posts.findIndex(p => p.id === id);
+    if (index === -1) {
+        return res.status(404).json({ message: 'Post not found' });
+    }
+    const post = posts[index];
+    const canDelete = ['manager', 'admin'].includes(req.user.role) || post.authorId === req.user.id;
+    if (!canDelete) return res.status(403).json({ message: 'Forbidden' });
+    posts.splice(index, 1);
+    addLog(`Deleted post ID ${id}`, req.user.username);
+    res.json({ message: 'Post deleted' });
+};
+
+module.exports = { listPosts, createPost, updatePost, deletePost };

--- a/server/controllers/user.controller.js
+++ b/server/controllers/user.controller.js
@@ -14,8 +14,8 @@ const createUser = async (req, res) => {
         return res.status(400).json({ message: 'All fields are required' });
     }
 
-    if (!['manager', 'employee'].includes(role)) {
-        return res.status(403).json({ message: 'Admins can only create Role A (manager) or Role B (employee)' });
+    if (!['admin', 'manager', 'employee'].includes(role)) {
+        return res.status(403).json({ message: 'Invalid role' });
     }
 
     const exists = users.find(u => u.username === username);
@@ -25,7 +25,7 @@ const createUser = async (req, res) => {
     const newUser = { id: nextId++, username, password: hash, role };
     users.push(newUser);
 
-    addLog(`Created ${role} account for '${username}'`, req.user.role);
+    addLog(`Created ${role} account for '${username}'`, req.user.username);
 
     res.json({ message: `User '${username}' created`, user: { id: newUser.id, username, role: newUser.role } });
 };
@@ -46,8 +46,8 @@ const updateUserRole = (req, res) => {
     const id = parseInt(req.params.id);
     const { role } = req.body;
 
-    if (!['manager', 'employee'].includes(role)) {
-        return res.status(403).json({ message: 'Admins can only assign manager or employee roles' });
+    if (!['admin', 'manager', 'employee'].includes(role)) {
+        return res.status(403).json({ message: 'Invalid role' });
     }
 
     const user = users.find(u => u.id === id);
@@ -60,6 +60,18 @@ const updateUserRole = (req, res) => {
     user.role = role;
     addLog(`Changed role of user ID ${id} to ${role}`, req.user.username);
     res.json({ message: 'Role updated', user: { id: user.id, username: user.username, role } });
+};
+
+const changePassword = async (req, res) => {
+    const { password } = req.body;
+    if (!password) {
+        return res.status(400).json({ message: 'Password is required' });
+    }
+    const user = users.find(u => u.id === req.user.id);
+    if (!user) return res.status(404).json({ message: 'User not found' });
+    user.password = await bcrypt.hash(password, 10);
+    addLog(`Changed password for user ID ${user.id}`, req.user.username);
+    res.json({ message: 'Password updated' });
 };
 
 const listUsers = (req, res) => {
@@ -80,5 +92,6 @@ module.exports = {
     getProfile,
     createUser,
     deleteUser,
-    updateUserRole
+    updateUserRole,
+    changePassword
 };

--- a/server/database.js
+++ b/server/database.js
@@ -6,4 +6,7 @@ const users = [
     { id: 3, username: 'employee', password: bcrypt.hashSync('employee123', 10), role: 'employee' },
 ];
 
-module.exports = { users };
+// In-memory storage for blog posts
+const posts = [];
+
+module.exports = { users, posts };

--- a/server/routes/post.routes.js
+++ b/server/routes/post.routes.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const { listPosts, createPost, updatePost, deletePost } = require('../controllers/post.controller');
+const { verifyToken } = require('../middlewares/auth.middleware');
+
+const router = express.Router();
+
+router.get('/', verifyToken, listPosts);
+router.post('/', verifyToken, createPost);
+router.put('/:id', verifyToken, updatePost);
+router.delete('/:id', verifyToken, deletePost);
+
+module.exports = router;

--- a/server/routes/user.routes.js
+++ b/server/routes/user.routes.js
@@ -4,7 +4,8 @@ const {
     getProfile,
     createUser,
     deleteUser,
-    updateUserRole
+    updateUserRole,
+    changePassword
 } = require('../controllers/user.controller');
 
 const { verifyToken } = require('../middlewares/auth.middleware');
@@ -26,5 +27,8 @@ router.delete('/:id', verifyToken, allowRoles('admin'), deleteUser);
 
 // --- Update User Role (Admin only) ---
 router.put('/:id/role', verifyToken, allowRoles('admin'), updateUserRole);
+
+// --- Change Own Password ---
+router.put('/password', verifyToken, changePassword);
 
 module.exports = router;

--- a/server/utils/logger.js
+++ b/server/utils/logger.js
@@ -1,0 +1,11 @@
+function info(action, user) {
+    const entry = {
+        level: 'info',
+        timestamp: new Date().toISOString(),
+        user,
+        action
+    };
+    console.log(JSON.stringify(entry));
+}
+
+module.exports = { info };


### PR DESCRIPTION
## Summary
- embed usernames in JWTs and store post author metadata with timestamps
- require auth for post endpoints and allow authors or managers to edit/delete their posts
- let admins create administrator accounts, reassign roles, change passwords, and filter audit logs

## Testing
- `npm test` (fails: Missing script "test")
- `node server/app.js` (server started then was terminated)


------
https://chatgpt.com/codex/tasks/task_e_688f253e2018832ea429e9e07897f9b1