### PR TITLE
Fix post authorship and add role management features

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -6,6 +6,7 @@
         <input name="username" placeholder="Username" required />
         <input name="password" type="password" placeholder="Password" required />
         <select name="role">
+            <option value="admin">Admin</option>
             <option value="manager">Manager</option>
             <option value="employee">Employee</option>
         </select>
@@ -20,8 +21,18 @@
 
 <section>
     <h3>Application Logs</h3>
+    <input id="logFilter" placeholder="Filter logs" />
     <button onclick="loadLogs()">View Logs</button>
     <ul id="logList"></ul>
+</section>
+
+<section>
+    <h3>Change Password</h3>
+    <form id="passwordForm">
+        <input name="oldPassword" type="password" placeholder="Old Password" required />
+        <input name="newPassword" type="password" placeholder="New Password" required />
+        <button type="submit">Change</button>
+    </form>
 </section>
 
 <script>
@@ -77,28 +88,38 @@
                 loadLogs();
             };
 
-            const promoteBtn = document.createElement('button');
-            promoteBtn.innerText = 'Make Manager';
-            promoteBtn.onclick = async () => {
+            const roleSelect = document.createElement('select');
+            ['admin','manager','employee'].forEach(r => {
+                const opt = document.createElement('option');
+                opt.value = r;
+                opt.textContent = r.charAt(0).toUpperCase() + r.slice(1);
+                if (r === user.role) opt.selected = true;
+                roleSelect.appendChild(opt);
+            });
+
+            const updateBtn = document.createElement('button');
+            updateBtn.innerText = 'Update Role';
+            updateBtn.onclick = async () => {
                 await fetch(`/api/users/${user.id}/role`, {
                     method: 'PUT',
                     headers: {
                         'Content-Type': 'application/json',
                         'Authorization': `Bearer ${token}`
                     },
-                    body: JSON.stringify({ role: 'manager' })
+                    body: JSON.stringify({ role: roleSelect.value })
                 });
                 loadUsers();
                 loadLogs();
             };
 
-            li.append(deleteBtn, promoteBtn);
+            li.append(deleteBtn, roleSelect, updateBtn);
             list.appendChild(li);
         });
     }
 
     async function loadLogs() {
-        const res = await fetch('/api/logs', {
+        const q = document.getElementById('logFilter').value;
+        const res = await fetch('/api/logs' + (q ? `?q=${encodeURIComponent(q)}` : ''), {
             headers: { 'Authorization': `Bearer ${token}` }
         });
         const logs = await res.json();
@@ -110,6 +131,24 @@
             logList.appendChild(li);
         });
     }
+
+    document.getElementById('passwordForm').addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const form = e.target;
+        const oldPassword = form.oldPassword.value;
+        const newPassword = form.newPassword.value;
+        const res = await fetch('/api/users/me/password', {
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${token}`
+            },
+            body: JSON.stringify({ oldPassword, newPassword })
+        });
+        const data = await res.json();
+        alert(data.message);
+        form.reset();
+    });
 
     loadUsers();
 </script>

--- a/public/employee.html
+++ b/public/employee.html
@@ -41,13 +41,37 @@
   });
 
   async function loadPosts() {
-    const res = await fetch('/api/posts');
+    const res = await fetch('/api/posts', {
+      headers: { 'Authorization': `Bearer ${token}` }
+    });
     const posts = await res.json();
     const list = document.getElementById('postList');
     list.innerHTML = '';
     posts.forEach(p => {
       const li = document.createElement('li');
-      li.textContent = `${p.author}: ${p.content}`;
+      li.textContent = `[${new Date(p.createdAt).toLocaleString()}] ${p.author}: ${p.content}`;
+      const editBtn = document.createElement('button');
+      editBtn.textContent = 'Edit';
+      editBtn.onclick = async () => {
+        const newContent = prompt('Edit post', p.content);
+        if (!newContent) return;
+        await fetch(`/api/posts/${p.id}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+          body: JSON.stringify({ content: newContent })
+        });
+        loadPosts();
+      };
+      const delBtn = document.createElement('button');
+      delBtn.textContent = 'Delete';
+      delBtn.onclick = async () => {
+        await fetch(`/api/posts/${p.id}`, {
+          method: 'DELETE',
+          headers: { 'Authorization': `Bearer ${token}` }
+        });
+        loadPosts();
+      };
+      li.append(editBtn, delBtn);
       list.appendChild(li);
     });
   }

--- a/public/manager.html
+++ b/public/manager.html
@@ -16,6 +16,15 @@
   <ul id="postList"></ul>
 </section>
 
+<section>
+  <h3>Change Password</h3>
+  <form id="passwordForm">
+    <input name="oldPassword" type="password" placeholder="Old Password" required />
+    <input name="newPassword" type="password" placeholder="New Password" required />
+    <button type="submit">Change</button>
+  </form>
+</section>
+
 <script>
   const token = localStorage.getItem('token');
 
@@ -41,13 +50,27 @@
   });
 
   async function loadPosts() {
-    const res = await fetch('/api/posts');
+    const res = await fetch('/api/posts', {
+      headers: { 'Authorization': `Bearer ${token}` }
+    });
     const posts = await res.json();
     const list = document.getElementById('postList');
     list.innerHTML = '';
     posts.forEach(p => {
       const li = document.createElement('li');
-      li.textContent = `${p.author}: ${p.content}`;
+      li.textContent = `[${new Date(p.createdAt).toLocaleString()}] ${p.author}: ${p.content}`;
+      const editBtn = document.createElement('button');
+      editBtn.textContent = 'Edit';
+      editBtn.onclick = async () => {
+        const newContent = prompt('Edit post', p.content);
+        if (!newContent) return;
+        await fetch(`/api/posts/${p.id}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+          body: JSON.stringify({ content: newContent })
+        });
+        loadPosts();
+      };
       const delBtn = document.createElement('button');
       delBtn.textContent = 'Delete';
       delBtn.onclick = async () => {
@@ -57,10 +80,28 @@
         });
         loadPosts();
       };
-      li.appendChild(delBtn);
+      li.append(editBtn, delBtn);
       list.appendChild(li);
     });
   }
+
+  document.getElementById('passwordForm').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const form = e.target;
+    const oldPassword = form.oldPassword.value;
+    const newPassword = form.newPassword.value;
+    const res = await fetch('/api/users/me/password', {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`
+      },
+      body: JSON.stringify({ oldPassword, newPassword })
+    });
+    const data = await res.json();
+    alert(data.message);
+    form.reset();
+  });
 
   loadPosts();
 </script>

--- a/server/controllers/auth.controller.js
+++ b/server/controllers/auth.controller.js
@@ -11,7 +11,7 @@ const login = async (req, res) => {
     const valid = await bcrypt.compare(password, user.password);
     if (!valid) return res.status(401).json({ message: 'Invalid password' });
 
-    const token = jwt.sign({ id: user.id, role: user.role }, SECRET, { expiresIn: '1h' });
+    const token = jwt.sign({ id: user.id, username: user.username, role: user.role }, SECRET, { expiresIn: '1h' });
     res.json({ token, role: user.role });
 };
 

--- a/server/controllers/log.controller.js
+++ b/server/controllers/log.controller.js
@@ -12,7 +12,13 @@ function addLog(action, user) {
 }
 
 const getLogs = (req, res) => {
-    res.json(logs);
+    const { q } = req.query;
+    const filtered = q
+        ? logs.filter(l =>
+            l.action.toLowerCase().includes(q.toLowerCase()) ||
+            l.user.toLowerCase().includes(q.toLowerCase()))
+        : logs;
+    res.json(filtered);
 };
 
 module.exports = { getLogs, addLog };

--- a/server/controllers/post.controller.js
+++ b/server/controllers/post.controller.js
@@ -4,7 +4,10 @@ const { addLog } = require('./log.controller');
 let nextId = 1;
 
 const listPosts = (req, res) => {
-    res.json(posts);
+    const visible = ['admin', 'manager'].includes(req.user.role)
+        ? posts
+        : posts.filter(p => p.author === req.user.username);
+    res.json(visible);
 };
 
 const createPost = (req, res) => {
@@ -12,9 +15,29 @@ const createPost = (req, res) => {
     if (!content) {
         return res.status(400).json({ message: 'Content is required' });
     }
-    const post = { id: nextId++, content, author: req.user.username };
+    const timestamp = new Date().toISOString();
+    const post = { id: nextId++, content, author: req.user.username, createdAt: timestamp, updatedAt: timestamp };
     posts.push(post);
     addLog(`Created post ID ${post.id}`, req.user.username);
+    res.json(post);
+};
+
+const updatePost = (req, res) => {
+    const id = parseInt(req.params.id);
+    const { content } = req.body;
+    const post = posts.find(p => p.id === id);
+    if (!post) {
+        return res.status(404).json({ message: 'Post not found' });
+    }
+    if (post.author !== req.user.username && !['admin', 'manager'].includes(req.user.role)) {
+        return res.status(403).json({ message: 'Forbidden' });
+    }
+    if (!content) {
+        return res.status(400).json({ message: 'Content is required' });
+    }
+    post.content = content;
+    post.updatedAt = new Date().toISOString();
+    addLog(`Updated post ID ${id}`, req.user.username);
     res.json(post);
 };
 
@@ -24,9 +47,13 @@ const deletePost = (req, res) => {
     if (index === -1) {
         return res.status(404).json({ message: 'Post not found' });
     }
+    const post = posts[index];
+    if (post.author !== req.user.username && !['admin', 'manager'].includes(req.user.role)) {
+        return res.status(403).json({ message: 'Forbidden' });
+    }
     posts.splice(index, 1);
     addLog(`Deleted post ID ${id}`, req.user.username);
     res.json({ message: 'Post deleted' });
 };
 
-module.exports = { listPosts, createPost, deletePost };
+module.exports = { listPosts, createPost, updatePost, deletePost };

--- a/server/routes/post.routes.js
+++ b/server/routes/post.routes.js
@@ -1,12 +1,12 @@
 const express = require('express');
-const { listPosts, createPost, deletePost } = require('../controllers/post.controller');
+const { listPosts, createPost, updatePost, deletePost } = require('../controllers/post.controller');
 const { verifyToken } = require('../middlewares/auth.middleware');
-const { allowRoles } = require('../middlewares/role.middleware');
 
 const router = express.Router();
 
-router.get('/', listPosts);
+router.get('/', verifyToken, listPosts);
 router.post('/', verifyToken, createPost);
-router.delete('/:id', verifyToken, allowRoles('admin', 'manager'), deletePost);
+router.put('/:id', verifyToken, updatePost);
+router.delete('/:id', verifyToken, deletePost);
 
 module.exports = router;

--- a/server/routes/user.routes.js
+++ b/server/routes/user.routes.js
@@ -4,7 +4,8 @@ const {
     getProfile,
     createUser,
     deleteUser,
-    updateUserRole
+    updateUserRole,
+    changePassword
 } = require('../controllers/user.controller');
 
 const { verifyToken } = require('../middlewares/auth.middleware');
@@ -17,6 +18,9 @@ router.get('/', verifyToken, allowRoles('admin', 'manager'), listUsers);
 
 // --- View Own Profile ---
 router.get('/me', verifyToken, getProfile);
+
+// --- Change Own Password ---
+router.put('/me/password', verifyToken, changePassword);
 
 // --- Create User (Admin only) ---
 router.post('/', verifyToken, allowRoles('admin'), createUser);


### PR DESCRIPTION
## Summary
- include usernames in JWT tokens and store timestamps for posts
- restrict post access to creators while allowing managers/admins to manage all posts
- add admin UI for creating admins, assigning roles, viewing filtered logs, and support password changes for admins and managers

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f29a64a74832ea3ea564218483328