### PR TITLE
Implement user registration with sessions and basic styling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,10 @@
         "bcrypt": "^6.0.0",
         "dotenv": "^17.2.1",
         "express": "^5.1.0",
+        "express-session": "^1.18.2",
         "jsonwebtoken": "^9.0.2",
         "nodemon": "^3.1.10"
-      },
-      "devDependencies": {}
+      }
     },
     "node_modules/accepts": {
       "version": "2.0.0",
@@ -392,6 +392,46 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/express-session": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.2.tgz",
+      "integrity": "sha512-SZjssGQC7TzTs9rpPDuUrR23GNZ9+2+IkA/+IJWmvQilTr5OSliEHGF+D9scbIpdC6yGtTI0/VhaHoVes2AN/A==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.7",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-headers": "~1.1.0",
+        "parseurl": "~1.3.3",
+        "safe-buffer": "5.2.1",
+        "uid-safe": "~2.1.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/express-session/node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/express-session/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express-session/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -907,6 +947,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -978,6 +1027,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/range-parser": {
@@ -1260,6 +1318,18 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "license": "MIT",
+      "dependencies": {
+        "random-bytes": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/undefsafe": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "bcrypt": "^6.0.0",
     "dotenv": "^17.2.1",
     "express": "^5.1.0",
+    "express-session": "^1.18.2",
     "jsonwebtoken": "^9.0.2",
     "nodemon": "^3.1.10"
   },

--- a/public/admin.html
+++ b/public/admin.html
@@ -1,4 +1,4 @@
-<h2>Admin Dashboard</h2>
+<h2 id="welcome">Admin Dashboard</h2>
 
 <section>
     <h3>Create User</h3>
@@ -37,6 +37,10 @@
 
 <script>
     const token = localStorage.getItem('token');
+
+    fetch('/api/auth/session').then(res => res.json()).then(u => {
+        document.getElementById('welcome').textContent = `Welcome, ${u.username}`;
+    }).catch(() => {});
 
     document.getElementById('createUserForm').addEventListener('submit', async (e) => {
         e.preventDefault();

--- a/public/employee.html
+++ b/public/employee.html
@@ -1,4 +1,4 @@
-<h2>Employee Dashboard</h2>
+<h2 id="welcome">Employee Dashboard</h2>
 <section>
   <button onclick="viewProfile()">View My Profile</button>
 </section>
@@ -18,6 +18,10 @@
 
 <script>
   const token = localStorage.getItem('token');
+
+  fetch('/api/auth/session').then(res => res.json()).then(u => {
+    document.getElementById('welcome').textContent = `Welcome, ${u.username}`;
+  }).catch(() => {});
 
   async function viewProfile() {
     const res = await fetch('/api/users/me', {

--- a/public/index.html
+++ b/public/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <title>Login</title>
+    <link rel="stylesheet" href="/style.css" />
 </head>
 <body>
 <h2>Login</h2>
@@ -11,6 +12,7 @@
     <input type="password" name="password" placeholder="Password" required />
     <button type="submit">Login</button>
 </form>
+<p>No account? <a href="/register.html">Register</a></p>
 <script src="/src/main.js"></script>
 </body>
 </html>

--- a/public/manager.html
+++ b/public/manager.html
@@ -1,4 +1,4 @@
-<h2>Manager Dashboard</h2>
+<h2 id="welcome">Manager Dashboard</h2>
 <section>
   <button onclick="viewUsers()">View Employees</button>
 </section>
@@ -27,6 +27,10 @@
 
 <script>
   const token = localStorage.getItem('token');
+
+  fetch('/api/auth/session').then(res => res.json()).then(u => {
+    document.getElementById('welcome').textContent = `Welcome, ${u.username}`;
+  }).catch(() => {});
 
   async function viewUsers() {
     const res = await fetch('/api/users', {

--- a/public/register.html
+++ b/public/register.html
@@ -2,9 +2,17 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Title</title>
+    <title>Register</title>
+    <link rel="stylesheet" href="/style.css" />
 </head>
 <body>
-
+<h2>Register</h2>
+<form id="registerForm">
+    <input type="text" name="username" placeholder="Username" required />
+    <input type="password" name="password" placeholder="Password" required />
+    <button type="submit">Register</button>
+</form>
+<p>Already have an account? <a href="/index.html">Login</a></p>
+<script src="/src/register.js"></script>
 </body>
 </html>

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,13 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 2rem;
+}
+form {
+  display: flex;
+  flex-direction: column;
+  max-width: 300px;
+}
+input, button {
+  margin: 0.5rem 0;
+  padding: 0.5rem;
+}

--- a/server/app.js
+++ b/server/app.js
@@ -1,6 +1,7 @@
 require('dotenv').config();
 const express = require('express');
 const path = require('path');
+const session = require('express-session');
 const app = express();
 
 const authRoutes = require('./routes/auth.routes');
@@ -9,6 +10,11 @@ const logRoutes = require('./routes/log.routes');
 const postRoutes = require('./routes/post.routes');
 
 app.use(express.json());
+app.use(session({
+    secret: process.env.SESSION_SECRET || 'secret',
+    resave: false,
+    saveUninitialized: false
+}));
 app.use('/api/auth', authRoutes);
 app.use('/api/users', userRoutes);
 app.use('/api/logs', logRoutes);

--- a/server/controllers/auth.controller.js
+++ b/server/controllers/auth.controller.js
@@ -1,6 +1,6 @@
 const jwt = require('jsonwebtoken');
 const bcrypt = require('bcrypt');
-const { findByUsername } = require('../models/user.model');
+const { findByUsername, createUser } = require('../models/user.model');
 const SECRET = process.env.JWT_SECRET;
 
 const login = async (req, res) => {
@@ -10,9 +10,28 @@ const login = async (req, res) => {
 
     const valid = await bcrypt.compare(password, user.password);
     if (!valid) return res.status(401).json({ message: 'Invalid password' });
-
     const token = jwt.sign({ id: user.id, username: user.username, role: user.role }, SECRET, { expiresIn: '1h' });
+    req.session.user = { id: user.id, username: user.username, role: user.role };
     res.json({ token, role: user.role });
 };
 
-module.exports = { login };
+const register = async (req, res) => {
+    const { username, password } = req.body;
+    if (!username || !password) return res.status(400).json({ message: 'Username and password required' });
+    if (findByUsername(username)) return res.status(409).json({ message: 'Username already exists' });
+    const hashed = await bcrypt.hash(password, 10);
+    const user = createUser({ username, password: hashed, role: 'employee' });
+    const token = jwt.sign({ id: user.id, username: user.username, role: user.role }, SECRET, { expiresIn: '1h' });
+    req.session.user = { id: user.id, username: user.username, role: user.role };
+    res.status(201).json({ token, role: user.role });
+};
+
+const session = (req, res) => {
+    if (req.session && req.session.user) {
+        res.json(req.session.user);
+    } else {
+        res.status(401).json({ message: 'Not authenticated' });
+    }
+};
+
+module.exports = { login, register, session };

--- a/server/models/user.model.js
+++ b/server/models/user.model.js
@@ -3,4 +3,11 @@ const { users } = require('../database');
 const findByUsername = (username) => users.find(u => u.username === username);
 const findById = (id) => users.find(u => u.id === id);
 
-module.exports = { findByUsername, findById };
+const createUser = ({ username, password, role }) => {
+    const id = users.length ? Math.max(...users.map(u => u.id)) + 1 : 1;
+    const user = { id, username, password, role };
+    users.push(user);
+    return user;
+};
+
+module.exports = { findByUsername, findById, createUser };

--- a/server/routes/auth.routes.js
+++ b/server/routes/auth.routes.js
@@ -1,6 +1,8 @@
 const express = require('express');
-const { login } = require('../controllers/auth.controller');
+const { login, register, session } = require('../controllers/auth.controller');
 const router = express.Router();
 
 router.post('/login', login);
+router.post('/register', register);
+router.get('/session', session);
 module.exports = router;

--- a/src/register.js
+++ b/src/register.js
@@ -1,0 +1,26 @@
+document.getElementById('registerForm').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const username = e.target.username.value;
+    const password = e.target.password.value;
+    const res = await fetch('/api/auth/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password })
+    });
+    const data = await res.json();
+    if (res.ok) {
+        localStorage.setItem('token', data.token);
+        switch (data.role) {
+            case 'admin':
+                window.location.href = '/admin.html';
+                break;
+            case 'manager':
+                window.location.href = '/manager.html';
+                break;
+            default:
+                window.location.href = '/employee.html';
+        }
+    } else {
+        alert(data.message);
+    }
+});


### PR DESCRIPTION
## Summary
- add express-session middleware to persist user sessions
- allow users to register and automatically login via new register route
- provide simple styles and registration page with client-side script

## Testing
- `node server/app.js` (server started)
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_688f2c70f364832e9bf809ae61565db8