### PR TITLE
Allow employees to view others' posts and add logout

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -1,4 +1,5 @@
 <h2 id="welcome">Admin Dashboard</h2>
+<button onclick="logout()">Logout</button>
 
 <section>
     <h3>Create User</h3>
@@ -39,8 +40,8 @@
     const token = localStorage.getItem('token');
 
     fetch('/api/auth/session').then(res => res.json()).then(u => {
-        document.getElementById('welcome').textContent = `Welcome, ${u.username}`;
-    }).catch(() => {});
+      document.getElementById('welcome').textContent = `Welcome, ${u.username}`;
+      }).catch(() => {});
 
     document.getElementById('createUserForm').addEventListener('submit', async (e) => {
         e.preventDefault();
@@ -154,5 +155,10 @@
         form.reset();
     });
 
-    loadUsers();
-</script>
+      loadUsers();
+      async function logout() {
+          await fetch('/api/auth/logout', { method: 'POST' });
+          localStorage.removeItem('token');
+          window.location.href = '/';
+      }
+  </script>

--- a/public/employee.html
+++ b/public/employee.html
@@ -1,4 +1,5 @@
 <h2 id="welcome">Employee Dashboard</h2>
+<button onclick="logout()">Logout</button>
 <section>
   <button onclick="viewProfile()">View My Profile</button>
 </section>
@@ -18,10 +19,15 @@
 
 <script>
   const token = localStorage.getItem('token');
+  let currentUser = null;
 
   fetch('/api/auth/session').then(res => res.json()).then(u => {
+    currentUser = u;
     document.getElementById('welcome').textContent = `Welcome, ${u.username}`;
-  }).catch(() => {});
+    loadPosts();
+  }).catch(() => {
+    loadPosts();
+  });
 
   async function viewProfile() {
     const res = await fetch('/api/users/me', {
@@ -54,31 +60,37 @@
     posts.forEach(p => {
       const li = document.createElement('li');
       li.textContent = `[${new Date(p.createdAt).toLocaleString()}] ${p.author}: ${p.content}`;
-      const editBtn = document.createElement('button');
-      editBtn.textContent = 'Edit';
-      editBtn.onclick = async () => {
-        const newContent = prompt('Edit post', p.content);
-        if (!newContent) return;
-        await fetch(`/api/posts/${p.id}`, {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
-          body: JSON.stringify({ content: newContent })
-        });
-        loadPosts();
-      };
-      const delBtn = document.createElement('button');
-      delBtn.textContent = 'Delete';
-      delBtn.onclick = async () => {
-        await fetch(`/api/posts/${p.id}`, {
-          method: 'DELETE',
-          headers: { 'Authorization': `Bearer ${token}` }
-        });
-        loadPosts();
-      };
-      li.append(editBtn, delBtn);
+      if (currentUser && p.author === currentUser.username) {
+        const editBtn = document.createElement('button');
+        editBtn.textContent = 'Edit';
+        editBtn.onclick = async () => {
+          const newContent = prompt('Edit post', p.content);
+          if (!newContent) return;
+          await fetch(`/api/posts/${p.id}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+            body: JSON.stringify({ content: newContent })
+          });
+          loadPosts();
+        };
+        const delBtn = document.createElement('button');
+        delBtn.textContent = 'Delete';
+        delBtn.onclick = async () => {
+          await fetch(`/api/posts/${p.id}`, {
+            method: 'DELETE',
+            headers: { 'Authorization': `Bearer ${token}` }
+          });
+          loadPosts();
+        };
+        li.append(editBtn, delBtn);
+      }
       list.appendChild(li);
     });
   }
 
-  loadPosts();
+  async function logout() {
+    await fetch('/api/auth/logout', { method: 'POST' });
+    localStorage.removeItem('token');
+    window.location.href = '/';
+  }
 </script>

--- a/public/manager.html
+++ b/public/manager.html
@@ -1,4 +1,5 @@
 <h2 id="welcome">Manager Dashboard</h2>
+<button onclick="logout()">Logout</button>
 <section>
   <button onclick="viewUsers()">View Employees</button>
 </section>
@@ -108,4 +109,9 @@
   });
 
   loadPosts();
-</script>
+  async function logout() {
+    await fetch('/api/auth/logout', { method: 'POST' });
+    localStorage.removeItem('token');
+    window.location.href = '/';
+  }
+  </script>

--- a/server/controllers/auth.controller.js
+++ b/server/controllers/auth.controller.js
@@ -34,4 +34,13 @@ const session = (req, res) => {
     }
 };
 
-module.exports = { login, register, session };
+const logout = (req, res) => {
+    req.session.destroy(err => {
+        if (err) {
+            return res.status(500).json({ message: 'Logout failed' });
+        }
+        res.json({ message: 'Logged out' });
+    });
+};
+
+module.exports = { login, register, session, logout };

--- a/server/controllers/post.controller.js
+++ b/server/controllers/post.controller.js
@@ -4,10 +4,8 @@ const { addLog } = require('./log.controller');
 let nextId = 1;
 
 const listPosts = (req, res) => {
-    const visible = ['admin', 'manager'].includes(req.user.role)
-        ? posts
-        : posts.filter(p => p.author === req.user.username);
-    res.json(visible);
+    // Allow all authenticated users to view every post
+    res.json(posts);
 };
 
 const createPost = (req, res) => {

--- a/server/routes/auth.routes.js
+++ b/server/routes/auth.routes.js
@@ -1,8 +1,9 @@
 const express = require('express');
-const { login, register, session } = require('../controllers/auth.controller');
+const { login, register, session, logout } = require('../controllers/auth.controller');
 const router = express.Router();
 
 router.post('/login', login);
 router.post('/register', register);
 router.get('/session', session);
+router.post('/logout', logout);
 module.exports = router;


### PR DESCRIPTION
## Summary
- Show all blog posts to authenticated users while keeping edit/delete restricted to authors, admins, or managers.
- Add logout endpoint and logout buttons across dashboards to end sessions.
- Employee dashboard only presents edit/delete controls for the current user's posts.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f2f5ccbb0832e93815f3ea326eb3d