### PR TITLE
feat: enhance dashboard navigation and logs

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -78,7 +78,12 @@
             <input type="date" id="logStart" class="border px-3 py-2 rounded" />
             <input type="date" id="logEnd" class="border px-3 py-2 rounded" />
             <input id="logFilter" placeholder="Filter details" class="flex-1 border px-3 py-2 rounded" />
+            <select id="logSort" class="border px-3 py-2 rounded" onchange="loadLogs()">
+                <option value="desc">Newest First</option>
+                <option value="asc">Oldest First</option>
+            </select>
             <button onclick="loadLogs()" class="bg-chan-green text-white px-4 py-2 rounded hover:bg-chan-orange">View Logs</button>
+            <button onclick="refreshLogs()" class="bg-chan-green text-white px-4 py-2 rounded hover:bg-chan-orange">Refresh</button>
         </div>
         <div id="logList" class="text-sm overflow-x-auto"></div>
     </section>
@@ -267,6 +272,7 @@
         const type = document.getElementById('logType').value;
         const start = document.getElementById('logStart').value;
         const end = document.getElementById('logEnd').value;
+        const sort = document.getElementById('logSort').value;
         const params = new URLSearchParams();
         if (q) params.append('q', q);
         if (type && type !== 'all') params.append('type', type);
@@ -284,7 +290,9 @@
         for (const [type, arr] of Object.entries(data.logs || {})) {
             arr.forEach(l => all.push({ ...l, type }));
         }
-        all.sort((a,b) => new Date(a.timestamp) - new Date(b.timestamp));
+        all.sort((a,b) => sort === 'asc'
+            ? new Date(a.timestamp) - new Date(b.timestamp)
+            : new Date(b.timestamp) - new Date(a.timestamp));
         const colors = {
             security: 'bg-yellow-100 text-yellow-800',
             errors: 'bg-red-100 text-red-800',
@@ -298,6 +306,10 @@
             tr.innerHTML = `<td class="p-2"><span class="px-2 py-1 rounded ${color}">${log.type}</span></td><td class="p-2">${new Date(log.timestamp).toLocaleString()}</td><td class="p-2">${message}${log.user ? ' - ' + log.user : ''}</td>`;
             tbody.appendChild(tr);
         });
+    }
+
+    function refreshLogs() {
+        loadLogs();
     }
 
     const newPasswordInput = document.getElementById('newPasswordInput');

--- a/public/employee.html
+++ b/public/employee.html
@@ -30,11 +30,20 @@
         <li id="lastFailedLogin"></li>
     </ul>
 
-    <section class="bg-white p-4 rounded shadow">
-        <button onclick="viewProfile()" class="bg-chan-green text-white px-4 py-2 rounded hover:bg-chan-orange">View My Profile</button>
+    <nav class="flex flex-wrap gap-2">
+        <button onclick="showSection('profile')" class="tab px-3 py-1 rounded bg-chan-green text-white">My Profile</button>
+        <button onclick="showSection('create')" class="tab px-3 py-1 rounded bg-chan-green text-white">Create Post</button>
+        <button onclick="showSection('posts')" class="tab px-3 py-1 rounded bg-chan-green text-white">Posts</button>
+        <button onclick="showSection('password')" class="tab px-3 py-1 rounded bg-chan-green text-white">Change Password</button>
+        <button onclick="showSection('recovery')" class="tab px-3 py-1 rounded bg-chan-green text-white">Update Recovery</button>
+    </nav>
+
+    <section id="section-profile" class="bg-white p-4 rounded shadow space-y-2">
+        <h3 class="text-xl font-semibold mb-4">My Profile</h3>
+        <div id="profileDetails" class="space-y-1 text-sm"></div>
     </section>
 
-    <section class="bg-white p-4 rounded shadow">
+    <section id="section-create" class="bg-white p-4 rounded shadow space-y-2 hidden">
         <h3 class="text-xl font-semibold mb-4">Create Post</h3>
         <form id="postForm" class="space-y-2">
             <textarea name="content" required class="w-full border px-3 py-2 rounded"></textarea>
@@ -42,12 +51,12 @@
         </form>
     </section>
 
-    <section class="bg-white p-4 rounded shadow">
+    <section id="section-posts" class="bg-white p-4 rounded shadow space-y-2 hidden">
         <h3 class="text-xl font-semibold mb-4">Posts</h3>
         <ul id="postList" class="space-y-1"></ul>
     </section>
 
-    <section class="bg-white p-4 rounded shadow">
+    <section id="section-password" class="bg-white p-4 rounded shadow space-y-2 hidden">
         <h3 class="text-xl font-semibold mb-4">Change Password</h3>
         <form id="passwordForm" class="space-y-2">
             <input name="oldPassword" type="password" placeholder="Old Password" required class="w-full border px-3 py-2 rounded" />
@@ -65,7 +74,7 @@
         </ul>
     </section>
 
-    <section class="bg-white p-4 rounded shadow">
+    <section id="section-recovery" class="bg-white p-4 rounded shadow space-y-2 hidden">
         <h3 class="text-xl font-semibold mb-4">Update Recovery</h3>
         <form id="recoveryForm" class="space-y-2">
             <input name="password" type="password" placeholder="Password" required id="recoveryPasswordInput" class="w-full border px-3 py-2 rounded"/>
@@ -79,25 +88,32 @@
   let currentUser = null;
 
   fetch('/api/auth/session').then(res => res.json()).then(u => {
-    currentUser = u;
+    currentUser = u.user;
     document.getElementById('welcome').textContent = `Welcome, ${u.user.username}`;
-    document.getElementById('lastSuccessfulLogin').textContent = u.user.lastLogin 
+    document.getElementById('lastSuccessfulLogin').textContent = u.user.lastLogin
       ? `Last successful login: ${new Date(u.user.lastLogin).toLocaleString()}`
       : 'Last successful login: Never';
-    document.getElementById('lastFailedLogin').textContent = u.user.lastFailedLogin 
+    document.getElementById('lastFailedLogin').textContent = u.user.lastFailedLogin
       ? `Last failed login: ${new Date(u.user.lastFailedLogin).toLocaleString()}`
       : 'Last failed login: Never';
-    loadPosts();
-  }).catch(() => {
-    loadPosts();
-  });
+  }).catch(() => {});
 
-  async function viewProfile() {
+  const sections = ['profile','create','posts','password','recovery'];
+  function showSection(id) {
+    sections.forEach(s => {
+      document.getElementById(`section-${s}`).classList.toggle('hidden', s !== id);
+    });
+    if (id === 'profile') loadProfile();
+    if (id === 'posts') loadPosts();
+  }
+
+  async function loadProfile() {
     const res = await fetch('/api/users/me', {
       headers: { 'Authorization': `Bearer ${token}` }
     });
     const data = await res.json();
-    alert(JSON.stringify(data));
+    const div = document.getElementById('profileDetails');
+    div.innerHTML = `<p>Username: ${data.username}</p><p>Role: ${data.role}</p>`;
   }
 
   document.getElementById('postForm').addEventListener('submit', async (e) => {
@@ -257,7 +273,7 @@
       alert(data.message || 'Password verification failed.');
     }
   });
-
+  showSection('profile');
   async function logout() {
     await fetch('/api/auth/logout', { method: 'POST' });
     localStorage.removeItem('token');

--- a/public/manager.html
+++ b/public/manager.html
@@ -30,11 +30,20 @@
         <li id="lastFailedLogin"></li>
     </ul>
 
-    <section class="bg-white p-4 rounded shadow">
-        <button onclick="viewUsers()" class="bg-chan-green text-white px-4 py-2 rounded hover:bg-chan-orange">View Employees</button>
+    <nav class="flex flex-wrap gap-2">
+        <button onclick="showSection('employees')" class="tab px-3 py-1 rounded bg-chan-green text-white">Employees</button>
+        <button onclick="showSection('create')" class="tab px-3 py-1 rounded bg-chan-green text-white">Create Post</button>
+        <button onclick="showSection('posts')" class="tab px-3 py-1 rounded bg-chan-green text-white">Posts</button>
+        <button onclick="showSection('password')" class="tab px-3 py-1 rounded bg-chan-green text-white">Change Password</button>
+        <button onclick="showSection('recovery')" class="tab px-3 py-1 rounded bg-chan-green text-white">Update Recovery</button>
+    </nav>
+
+    <section id="section-employees" class="bg-white p-4 rounded shadow space-y-2">
+        <h3 class="text-xl font-semibold mb-4">Employees</h3>
+        <ul id="employeeList" class="space-y-1"></ul>
     </section>
 
-    <section class="bg-white p-4 rounded shadow">
+    <section id="section-create" class="bg-white p-4 rounded shadow space-y-2 hidden">
         <h3 class="text-xl font-semibold mb-4">Create Post</h3>
         <form id="postForm" class="space-y-2">
             <textarea name="content" required class="w-full border px-3 py-2 rounded"></textarea>
@@ -42,12 +51,12 @@
         </form>
     </section>
 
-    <section class="bg-white p-4 rounded shadow">
+    <section id="section-posts" class="bg-white p-4 rounded shadow space-y-2 hidden">
         <h3 class="text-xl font-semibold mb-4">Posts</h3>
         <ul id="postList" class="space-y-1"></ul>
     </section>
 
-    <section class="bg-white p-4 rounded shadow">
+    <section id="section-password" class="bg-white p-4 rounded shadow space-y-2 hidden">
         <h3 class="text-xl font-semibold mb-4">Change Password</h3>
         <form id="passwordForm" class="space-y-2">
             <input name="oldPassword" type="password" placeholder="Old Password" required class="w-full border px-3 py-2 rounded" />
@@ -65,7 +74,7 @@
         </ul>
     </section>
 
-    <section class="bg-white p-4 rounded shadow">
+    <section id="section-recovery" class="bg-white p-4 rounded shadow space-y-2 hidden">
         <h3 class="text-xl font-semibold mb-4">Update Recovery</h3>
         <form id="recoveryForm" class="space-y-2">
             <input name="password" type="password" placeholder="Password" required id="recoveryPasswordInput" class="w-full border px-3 py-2 rounded"/>
@@ -87,12 +96,65 @@
       : 'Last failed login: Never';
   }).catch(() => {});
 
-  async function viewUsers() {
+  const sections = ['employees','create','posts','password','recovery'];
+  function showSection(id) {
+    sections.forEach(s => {
+      document.getElementById(`section-${s}`).classList.toggle('hidden', s !== id);
+    });
+    if (id === 'employees') loadEmployees();
+    if (id === 'posts') loadPosts();
+  }
+
+  async function loadEmployees() {
     const res = await fetch('/api/users', {
       headers: { 'Authorization': `Bearer ${token}` }
     });
-    const data = await res.json();
-    alert(JSON.stringify(data));
+    const users = await res.json();
+    const list = document.getElementById('employeeList');
+    list.innerHTML = '';
+    users.forEach(user => {
+      const li = document.createElement('li');
+      li.textContent = `${user.username} (${user.role})`;
+
+      const deleteBtn = document.createElement('button');
+      deleteBtn.innerText = 'Delete';
+      deleteBtn.className = 'ml-2 px-2 py-1 bg-red-500 text-white rounded';
+      deleteBtn.onclick = async () => {
+        await fetch(`/api/users/${user.id}`, {
+          method: 'DELETE',
+          headers: { 'Authorization': `Bearer ${token}` }
+        });
+        loadEmployees();
+      };
+
+      const roleSelect = document.createElement('select');
+      roleSelect.className = 'ml-2 border rounded';
+      ['admin','manager','employee'].forEach(r => {
+        const opt = document.createElement('option');
+        opt.value = r;
+        opt.textContent = r.charAt(0).toUpperCase() + r.slice(1);
+        if (r === user.role) opt.selected = true;
+        roleSelect.appendChild(opt);
+      });
+
+      const updateBtn = document.createElement('button');
+      updateBtn.innerText = 'Update Role';
+      updateBtn.className = 'ml-2 px-2 py-1 bg-chan-green text-white rounded';
+      updateBtn.onclick = async () => {
+        await fetch(`/api/users/${user.id}/role`, {
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${token}`
+          },
+          body: JSON.stringify({ role: roleSelect.value })
+        });
+        loadEmployees();
+      };
+
+      li.append(deleteBtn, roleSelect, updateBtn);
+      list.appendChild(li);
+    });
   }
 
   document.getElementById('postForm').addEventListener('submit', async (e) => {
@@ -257,7 +319,7 @@
     }
   });
 
-  loadPosts();
+  showSection('employees');
   async function logout() {
     await fetch('/api/auth/logout', { method: 'POST' });
     localStorage.removeItem('token');

--- a/server/routes/user.routes.js
+++ b/server/routes/user.routes.js
@@ -29,10 +29,10 @@ router.put('/me/password', verifyToken, changePassword);
 router.post('/', verifyToken, allowRoles('admin'), createUser);
 
 // --- Delete User (Admin only) ---
-router.delete('/:id', verifyToken, allowRoles('admin'), deleteUser);
+router.delete('/:id', verifyToken, allowRoles('admin', 'manager'), deleteUser);
 
 // --- Update User Role (Admin only) ---
-router.put('/:id/role', verifyToken, allowRoles('admin'), updateUserRole);
+router.put('/:id/role', verifyToken, allowRoles('admin', 'manager'), updateUserRole);
 
 // --- Update Recovery Questions ---
 router.put('/me/recovery', verifyToken, updateRecovery);


### PR DESCRIPTION
## Summary
- add sorting and refresh controls for admin log viewer
- refactor manager and employee dashboards into tabbed pages with improved employee management
- permit managers to modify employee accounts

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6890da125b6c832eb65cc5762e30cc88